### PR TITLE
chore: keep only stable API version when generate APIs

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -312,8 +312,13 @@ async function generateModels() {
     const githubDirectories = await fetchContentsByPath()
     const githubFilePromises = githubDirectories.map((directory) =>
       fetchContentsByPath(directory.path)
-        // Only keep latest version
-        .then((files) => files[files.length - 1]),
+        /**
+         * API model directory contains both preview and stable version.
+         * Therefore, keep only available API version.
+         *
+         * Docs: https://github.com/amzn/selling-partner-api-docs/issues/646#issuecomment-825232385
+         */
+        .then((files) => files[0]),
     )
 
     const githubFiles = await Promise.all(githubFilePromises)


### PR DESCRIPTION
> The new version of the reports API is not yet available to use. It has been provided to understand the changes that would be made to the API. You will still use version "2020-09-04". Once the new reports API is available for use, we will remove the older version from the GitHub repository.

There are both preview and stable API model inside a directory.
I've updated our API model generation script to generate only stable version.

Ref: https://github.com/amzn/selling-partner-api-docs/issues/646#issuecomment-825232385

Closes #74 