### PR TITLE
ci: set default lookback hour for schedule workflow

### DIFF
--- a/.github/workflows/generate-models.yml
+++ b/.github/workflows/generate-models.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: adopt
+          java-version: 11
 
       - name: Install
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/generate-models.yml
+++ b/.github/workflows/generate-models.yml
@@ -9,7 +9,8 @@ on:
         description: Lookback Hours
         required: true
         default: "26"
-
+env:
+  DEFAULT_LOOKBACK_HOURS: 26
 jobs:
   generate:
     name: Generate
@@ -42,7 +43,7 @@ jobs:
           # The schedule event can be delayed during periods of high loads.
           # Therefore, we need to buffer around 2 hours.
           # Docs: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
-          LOOKBACK_HOURS: ${{ github.event.inputs.lookbackHours }}
+          LOOKBACK_HOURS: ${{ github.event.inputs.lookbackHours || env.DEFAULT_LOOKBACK_HOURS }}
 
       - name: Lint
         run: npm run lint:fix


### PR DESCRIPTION
Fix: https://github.com/ScaleLeap/selling-partner-api-sdk/actions/runs/811972671