### PR TITLE
fix: error code and message are no longer undefined

### DIFF
--- a/src/helpers/api-error-factory.ts
+++ b/src/helpers/api-error-factory.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 import { ExtendableError } from 'ts-error'
 
 import {
-  ModelError,
+  ModelErrorContainer,
   SellingPartnerBadRequestError,
   SellingPartnerForbiddenError,
   SellingPartnerGenericError,
@@ -15,29 +15,36 @@ import {
   SellingPartnerUnsupportedMediaTypeError,
 } from '../types'
 
-export function apiErrorFactory<T extends ModelError>(error: AxiosError<T>): ExtendableError {
+export function apiErrorFactory<T extends ModelErrorContainer>(
+  error: AxiosError<T>,
+): ExtendableError {
   const { response } = error
   if (response) {
     const { headers, data } = response
+    const modelError = data.errors[0] || {
+      code: 'Unknown',
+      message: '',
+    }
+
     switch (response.status) {
       case StatusCodes.BAD_REQUEST:
-        return new SellingPartnerBadRequestError(data, headers)
+        return new SellingPartnerBadRequestError(modelError, headers)
       case StatusCodes.FORBIDDEN:
-        return new SellingPartnerForbiddenError(data, headers)
+        return new SellingPartnerForbiddenError(modelError, headers)
       case StatusCodes.NOT_FOUND:
-        return new SellingPartnerNotFoundError(data, headers)
+        return new SellingPartnerNotFoundError(modelError, headers)
       case StatusCodes.REQUEST_TOO_LONG:
-        return new SellingPartnerRequestTooLongError(data, headers)
+        return new SellingPartnerRequestTooLongError(modelError, headers)
       case StatusCodes.UNSUPPORTED_MEDIA_TYPE:
-        return new SellingPartnerUnsupportedMediaTypeError(data, headers)
+        return new SellingPartnerUnsupportedMediaTypeError(modelError, headers)
       case StatusCodes.TOO_MANY_REQUESTS:
-        return new SellingPartnerTooManyRequestsError(data, headers)
+        return new SellingPartnerTooManyRequestsError(modelError, headers)
       case StatusCodes.INTERNAL_SERVER_ERROR:
-        return new SellingPartnerInternalServerError(data, headers)
+        return new SellingPartnerInternalServerError(modelError, headers)
       case StatusCodes.SERVICE_UNAVAILABLE:
-        return new SellingPartnerServiceUnavailableError(data, headers)
+        return new SellingPartnerServiceUnavailableError(modelError, headers)
       default:
-        return new SellingPartnerGenericError(data, headers)
+        return new SellingPartnerGenericError(modelError, headers)
     }
   } else {
     return error

--- a/src/helpers/api-error-factory.ts
+++ b/src/helpers/api-error-factory.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 import { ExtendableError } from 'ts-error'
 
 import {
+  ModelError,
   ModelErrorContainer,
   SellingPartnerBadRequestError,
   SellingPartnerForbiddenError,
@@ -12,6 +13,7 @@ import {
   SellingPartnerRequestTooLongError,
   SellingPartnerServiceUnavailableError,
   SellingPartnerTooManyRequestsError,
+  SellingPartnerUnknownError,
   SellingPartnerUnsupportedMediaTypeError,
 } from '../types'
 
@@ -21,9 +23,15 @@ export function apiErrorFactory<T extends ModelErrorContainer>(
   const { response } = error
   if (response) {
     const { headers, data } = response
-    const modelError = data.errors[0] || {
-      code: 'Unknown',
-      message: '',
+    const modelError: ModelError | undefined = data.errors[0]
+    if (modelError === undefined) {
+      return new SellingPartnerUnknownError(
+        {
+          code: 'UnknownError',
+          message: 'Selling Partner API unknown error',
+        },
+        headers,
+      )
     }
 
     switch (response.status) {

--- a/src/types/errors/selling-partner-api-errors.ts
+++ b/src/types/errors/selling-partner-api-errors.ts
@@ -1,6 +1,10 @@
 /* eslint-disable max-classes-per-file */
 import { ExtendableError } from 'ts-error'
 
+export interface ModelErrorContainer {
+  errors: ModelError[]
+}
+
 export interface ModelError {
   /**
    * An error code that identifies the type of error that occurred.

--- a/src/types/errors/selling-partner-api-errors.ts
+++ b/src/types/errors/selling-partner-api-errors.ts
@@ -63,5 +63,6 @@ export class SellingPartnerTooManyRequestsError extends SellingPartnerGenericErr
 }
 export class SellingPartnerInternalServerError extends SellingPartnerGenericError {}
 export class SellingPartnerServiceUnavailableError extends SellingPartnerGenericError {}
+export class SellingPartnerUnknownError extends SellingPartnerGenericError {}
 
 /* eslint-enable max-classes-per-file */

--- a/test/types/errors/errors.test.ts
+++ b/test/types/errors/errors.test.ts
@@ -32,6 +32,14 @@ describe(`client`, () => {
       .any(`${CA.sellingPartner.region.endpoint}/sellers/v1/marketplaceParticipations`)
       .intercept((request, response) => {
         response.setHeader('x-amzn-requestid', requestId).sendStatus(StatusCodes.FORBIDDEN)
+        response.send({
+          errors: [
+            {
+              code: 'Forbidden',
+              message: 'Forbidden',
+            },
+          ],
+        })
       })
 
     const client = new SellersApiClient(configuration)
@@ -100,6 +108,14 @@ describe(`client`, () => {
         response
           .setHeader('x-amzn-RateLimit-Limit', defaultRateLimit)
           .sendStatus(StatusCodes.TOO_MANY_REQUESTS)
+        response.send({
+          errors: [
+            {
+              code: 'TooManyRequests',
+              message: 'Too many requests',
+            },
+          ],
+        })
       })
 
     const configuration: APIConfigurationParameters = {


### PR DESCRIPTION
### What was the problem?
Errors returned by the SDK were kind of useless, because `code` and `message` fields were undefined.

### Fix
The code assumed that Amazon returns an error as a single object with `code` and `message` fields, but actually they return it as an array of such objects. I made small changes to resolve this issue.
