### PR TITLE
fix: error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8644,9 +8644,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -14857,9 +14857,9 @@
       }
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true
     },
     "xml-name-validator": {

--- a/src/helpers/api-error-factory.ts
+++ b/src/helpers/api-error-factory.ts
@@ -21,9 +21,12 @@ export function apiErrorFactory<T extends ModelErrorContainer>(
   error: AxiosError<T>,
 ): ExtendableError {
   const { response } = error
+
   if (response) {
     const { headers, data } = response
-    const modelError: ModelError | undefined = data.errors[0]
+
+    const modelError: ModelError | undefined = data?.errors?.shift()
+
     if (modelError === undefined) {
       return new SellingPartnerUnknownError(
         {

--- a/src/helpers/api-error-factory.ts
+++ b/src/helpers/api-error-factory.ts
@@ -3,7 +3,6 @@ import { StatusCodes } from 'http-status-codes'
 import { ExtendableError } from 'ts-error'
 
 import {
-  ModelError,
   ModelErrorContainer,
   SellingPartnerBadRequestError,
   SellingPartnerForbiddenError,
@@ -25,7 +24,7 @@ export function apiErrorFactory<T extends ModelErrorContainer>(
   if (response) {
     const { headers, data } = response
 
-    const modelError: ModelError | undefined = data?.errors?.shift()
+    const modelError = data?.errors?.shift()
 
     if (modelError === undefined) {
       return new SellingPartnerUnknownError(


### PR DESCRIPTION
Fixes error handling when error shape does not correspond to what is defined in the API.

When `data.error` does not exist the following error is thrown:

```
TypeError: Cannot read property '0' of undefined
```

---

- fix: npm audit
- fix: error access error
