### PR TITLE
fix: add missing methods when generate api clients

### DIFF
--- a/src/helpers/apply-mixins.ts
+++ b/src/helpers/apply-mixins.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+export function applyMixins(derivedCtor: any, baseCtors: any[]): void {
+  for (const baseCtor of baseCtors) {
+    for (const name of Object.getOwnPropertyNames(baseCtor.prototype)) {
+      const baseCtorName = Object.getOwnPropertyDescriptor(baseCtor.prototype, name)
+      if (baseCtorName) {
+        Object.defineProperty(derivedCtor.prototype, name, baseCtorName)
+      }
+    }
+  }
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './api-client-helpers'
 export * from './api-error-factory'
+export * from './apply-mixins'

--- a/test/authentication.ts
+++ b/test/authentication.ts
@@ -1,0 +1,56 @@
+import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts'
+import axios from 'axios'
+
+import { APIConfigurationParameters } from '../src'
+import * as environment from './environment'
+
+export interface TokenResponse {
+  /* eslint-disable camelcase */
+  access_token: string
+  expires_in: number
+  refresh_token: string
+  /* eslint-enable camelcase */
+}
+
+export async function getTokens(): Promise<TokenResponse> {
+  const { data: tokens } = await axios.post<TokenResponse>('https://api.amazon.com/auth/o2/token', {
+    grant_type: 'refresh_token',
+    client_id: environment.CLIENT_ID,
+    client_secret: environment.CLIENT_SECRET,
+    refresh_token: environment.REFRESH_TOKEN,
+  })
+
+  return tokens
+}
+
+export async function generateAPIConfigurations(
+  region: string,
+  basePath: string,
+  tokens: TokenResponse,
+): Promise<APIConfigurationParameters> {
+  const sts = new STSClient({
+    region,
+    credentials: {
+      accessKeyId: environment.AWS_ACCESS_KEY_ID,
+      secretAccessKey: environment.AWS_SECRET_ACCESS_KEY,
+    },
+  })
+
+  const { Credentials } = await sts.send(
+    new AssumeRoleCommand({
+      RoleArn: environment.ROLE_ARN,
+      RoleSessionName: 'selling-partner-api-axios',
+    }),
+  )
+
+  return {
+    basePath,
+    region,
+    accessToken: tokens.access_token,
+    credentials: {
+      accessKeyId: Credentials?.AccessKeyId || '',
+      secretAccessKey: Credentials?.SecretAccessKey || '',
+      sessionToken: Credentials?.SessionToken || '',
+    },
+  }
+}

--- a/test/integration/sellers-api-client.test.ts
+++ b/test/integration/sellers-api-client.test.ts
@@ -1,34 +1,12 @@
-import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts'
-import axios from 'axios'
-
 import { APIConfigurationParameters, ReportsApiClient } from '../../src'
 import { SellersApiClient } from '../../src/api-clients/sellers-api-client'
-import * as environment from '../environment'
-
-interface TokenResponse {
-  /* eslint-disable camelcase */
-  access_token: string
-  expires_in: number
-  refresh_token: string
-  /* eslint-enable camelcase */
-}
+import { generateAPIConfigurations, getTokens, TokenResponse } from '../authentication'
 
 const regions: [string, string][] = [
   ['us-east-1', 'https://sellingpartnerapi-na.amazon.com'],
   // ['eu-west-1', 'https://sandbox.sellingpartnerapi-eu.amazon.com'],
   // ['us-west-2', ''],
 ]
-
-async function getTokens() {
-  const { data: tokens } = await axios.post<TokenResponse>('https://api.amazon.com/auth/o2/token', {
-    grant_type: 'refresh_token',
-    client_id: environment.CLIENT_ID,
-    client_secret: environment.CLIENT_SECRET,
-    refresh_token: environment.REFRESH_TOKEN,
-  })
-
-  return tokens
-}
 
 jest.setTimeout(24 * 1000)
 
@@ -39,35 +17,7 @@ describe(`${SellersApiClient.name}`, () => {
 
     beforeAll(async () => {
       tokens = await getTokens()
-    })
-
-    // eslint-disable-next-line jest/no-duplicate-hooks
-    beforeAll(async () => {
-      const sts = new STSClient({
-        region,
-        credentials: {
-          accessKeyId: environment.AWS_ACCESS_KEY_ID,
-          secretAccessKey: environment.AWS_SECRET_ACCESS_KEY,
-        },
-      })
-
-      const { Credentials } = await sts.send(
-        new AssumeRoleCommand({
-          RoleArn: environment.ROLE_ARN,
-          RoleSessionName: 'selling-partner-api-axios',
-        }),
-      )
-
-      apiConfigurationParameters = {
-        basePath,
-        region,
-        accessToken: tokens.access_token,
-        credentials: {
-          accessKeyId: Credentials?.AccessKeyId || '',
-          secretAccessKey: Credentials?.SecretAccessKey || '',
-          sessionToken: Credentials?.SessionToken || '',
-        },
-      }
+      apiConfigurationParameters = await generateAPIConfigurations(region, basePath, tokens)
     })
 
     it('should return the list of marketplaces', async () => {

--- a/test/integration/vendor-direct-fulfillment-shipping-api-client.test.ts
+++ b/test/integration/vendor-direct-fulfillment-shipping-api-client.test.ts
@@ -1,0 +1,38 @@
+import { APIConfigurationParameters, VendorDirectFulfillmentShippingApiClient } from '../../src'
+import { generateAPIConfigurations, getTokens, TokenResponse } from '../authentication'
+
+const regions: [string, string][] = [
+  ['us-east-1', 'https://sandbox.sellingpartnerapi-na.amazon.com'],
+]
+
+jest.setTimeout(24 * 1000)
+
+// TODO: need to check again when grant access to resource
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip(`${VendorDirectFulfillmentShippingApiClient.name}`, () => {
+  describe.each(regions)('for region %s', (region, basePath) => {
+    let tokens: TokenResponse
+    let apiConfigurationParameters: APIConfigurationParameters
+
+    beforeAll(async () => {
+      tokens = await getTokens()
+      apiConfigurationParameters = await generateAPIConfigurations(region, basePath, tokens)
+    })
+
+    it('should return the list of object', async () => {
+      expect.assertions(1)
+
+      const client = new VendorDirectFulfillmentShippingApiClient(apiConfigurationParameters)
+
+      const parameters = {
+        createdBefore: '2020-02-20T00:00:00-08:00',
+        createdAfter: '2020-02-15T14:00:00-08:00',
+        limit: 2,
+      }
+
+      const { data: labels } = await client.getShippingLabels(parameters)
+
+      expect(labels.payload).toBeInstanceOf(Array)
+    })
+  })
+})

--- a/utils/generator/api-client-template.ts
+++ b/utils/generator/api-client-template.ts
@@ -1,5 +1,5 @@
-export const apiClientTemplate = `import { <%= apiModelClassName %>, Configuration } from '../api-models/<%= dirname %>'
-import { ApiClientHelpers } from '../helpers'
+export const apiClientTemplate = `import { <%= importApiModelClassName %>, Configuration } from '../api-models/<%= dirname %>'
+import { <%= importHelpers %> } from '../helpers'
 import { DEFAULT_API_BASE_PATH } from '../types'
 import { APIConfigurationParameters } from '../types/api-clients/api-configuration-parameters'
 
@@ -12,4 +12,5 @@ export class <%= apiClientClassName %> extends <%= apiModelClassName %> {
     super(configuration, DEFAULT_API_BASE_PATH, axios)
   }
 }
+<%= extendable %>
 `


### PR DESCRIPTION
- Find all API base classes in API model.
- Extend multiple API base classes in API clients.