### PR TITLE
fix: re-generate missing method in API clients

### DIFF
--- a/src/api-clients/vendor-direct-fulfillment-shipping-api-client.ts
+++ b/src/api-clients/vendor-direct-fulfillment-shipping-api-client.ts
@@ -1,8 +1,10 @@
 import {
   Configuration,
   CustomerInvoicesApi,
+  VendorShippingApi,
+  VendorShippingLabelsApi,
 } from '../api-models/vendor-direct-fulfillment-shipping-api-model'
-import { ApiClientHelpers } from '../helpers'
+import { ApiClientHelpers, applyMixins } from '../helpers'
 import { DEFAULT_API_BASE_PATH } from '../types'
 import { APIConfigurationParameters } from '../types/api-clients/api-configuration-parameters'
 
@@ -15,3 +17,13 @@ export class VendorDirectFulfillmentShippingApiClient extends CustomerInvoicesAp
     super(configuration, DEFAULT_API_BASE_PATH, axios)
   }
 }
+
+export interface VendorDirectFulfillmentShippingApiClient
+  extends CustomerInvoicesApi,
+    VendorShippingApi,
+    VendorShippingLabelsApi {}
+applyMixins(VendorDirectFulfillmentShippingApiClient, [
+  CustomerInvoicesApi,
+  VendorShippingApi,
+  VendorShippingLabelsApi,
+])


### PR DESCRIPTION
- Re-generate model when apply changes in https://github.com/ScaleLeap/selling-partner-api-sdk/pull/203