### PR TITLE
ci: use Node v14 for release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
       - name: Install
         uses: bahmutov/npm-install@v1
 


### PR DESCRIPTION
I didn't find out the reason why our \`@scaleleap/semantic\-release\-config\` couldn't be installed pior to execution.
This forced \`npx\` to execute packages from a local and it worked.

GH Actions logs from my fork repo: https://github.com/nguyentoanit/selling-partner-api-sdk/runs/4481344350?check_suite_focus=true