### PR TITLE
fix: skip lib check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
       "DOM"
     ],
     "noImplicitAny": false,
-    "target": "ES2019"
+    "target": "ES2019",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This resolves [the compilation error in CI](https://github.com/ScaleLeap/selling-partner-api-sdk/runs/8105148958?check_suite_focus=true).

Looks like TS [v4.8.2](https://github.com/microsoft/TypeScript/tree/v4.8.2) was checking declaration files in `node_modules` under the hood.

I didn't figure out a better way to resolve this.
Please let me know if you have any idea for this. Thanks.


