### PR TITLE
Revert "chore(deps): update dependency ts-morph to v17"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "openapi-types": "12.0.2",
         "rimraf": "3.0.2",
         "ts-jest": "29.0.3",
-        "ts-morph": "17.0.0",
+        "ts-morph": "16.0.0",
         "ts-node": "10.9.1",
         "ts-node-dev": "2.0.0",
         "tsconfigs": "4.0.2",
@@ -3594,12 +3594,12 @@
       }
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.18.0.tgz",
-      "integrity": "sha512-UvWF+oQdMa4qMWhXTOd2JWtAbAJGgkPMNzGHgEcfOwQRIcViKdwsSqXXjSaQCZ4fo+bZMhdfuwQCjlW5bNcqEQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
       "dev": true,
       "dependencies": {
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.2.11",
         "minimatch": "^5.1.0",
         "mkdirp": "^1.0.4",
         "path-browserify": "^1.0.1"
@@ -7632,9 +7632,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -13676,12 +13676,12 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-17.0.0.tgz",
-      "integrity": "sha512-EJxyHTpBXsYnOgV6UpYs4vjhMS/8IZXg5kkGcM9+b8SygMmmOoeWOpaSG8E4puhewjkIbUObodGhfJkBoFX3og==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
       "dev": true,
       "dependencies": {
-        "@ts-morph/common": "~0.18.0",
+        "@ts-morph/common": "~0.17.0",
         "code-block-writer": "^11.0.3"
       }
     },
@@ -17333,12 +17333,12 @@
       "dev": true
     },
     "@ts-morph/common": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.18.0.tgz",
-      "integrity": "sha512-UvWF+oQdMa4qMWhXTOd2JWtAbAJGgkPMNzGHgEcfOwQRIcViKdwsSqXXjSaQCZ4fo+bZMhdfuwQCjlW5bNcqEQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
       "dev": true,
       "requires": {
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.2.11",
         "minimatch": "^5.1.0",
         "mkdirp": "^1.0.4",
         "path-browserify": "^1.0.1"
@@ -20422,9 +20422,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -24978,12 +24978,12 @@
       }
     },
     "ts-morph": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-17.0.0.tgz",
-      "integrity": "sha512-EJxyHTpBXsYnOgV6UpYs4vjhMS/8IZXg5kkGcM9+b8SygMmmOoeWOpaSG8E4puhewjkIbUObodGhfJkBoFX3og==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
       "dev": true,
       "requires": {
-        "@ts-morph/common": "~0.18.0",
+        "@ts-morph/common": "~0.17.0",
         "code-block-writer": "^11.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "openapi-types": "12.0.2",
     "rimraf": "3.0.2",
     "ts-jest": "29.0.3",
-    "ts-morph": "17.0.0",
+    "ts-morph": "16.0.0",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
     "tsconfigs": "4.0.2",


### PR DESCRIPTION
Reverts ScaleLeap/selling-partner-api-sdk#637

There was a falling test when generating models in v17.
Need to be fixed before merging.