### PR TITLE
chore: update node version for release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
Looks like, `typedoc` doesn't work well on Node.js 14.
This PR will upgrade Node.js version in `release` CI.